### PR TITLE
GL - fix navbar spelling ucsbdiningcommonsmenuitem

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -79,7 +79,7 @@ export default function AppNavbar({
                     UCSB Dates
                   </Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitem">
-                    UCSB Dining Commons MenuItem
+                    UCSB Dining Commons Menu Item
                   </Nav.Link>
                   <Nav.Link as={Link} to="/ucsborganizations">
                     UCSB Organizations

--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
@@ -21,7 +21,7 @@ public class UCSBDiningCommonsMenuItemWebIT extends WebTestCase {
     public void admin_user_can_create_edit_delete_dining_commons_menu_item() throws Exception {
         setupUser(true);
 
-        page.getByText("UCSB Dining Commons MenuItem").click();
+        page.getByText("UCSB Dining Commons Menu Item").click();
 
         page.getByText("Create UCSBDiningCommonsMenuItem").click();
         assertThat(page.getByText("Create New UCSBDiningCommonsMenuItem")).isVisible();
@@ -53,7 +53,7 @@ public class UCSBDiningCommonsMenuItemWebIT extends WebTestCase {
     public void regular_user_cannot_create_UCSBDiningCommonsMenuItem() throws Exception {
         setupUser(false);
 
-        page.getByText("UCSB Dining Commons MenuItem").click();
+        page.getByText("UCSB Dining Commons Menu Item").click();
 
         assertThat(page.getByText("Create UCSBDiningCommonsMenuItem")).not().isVisible();
         assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name")).not().isVisible();


### PR DESCRIPTION
Fixes a simple spelling error in the navbar. Updates corresponding e2e tests to match.